### PR TITLE
rxing repository has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ library implemented in Java, with ports to other languages.
 | [zxing-js/library](https://github.com/zxing-js/library)                                   | TypeScript port of ZXing library
 | [pyzxing](https://github.com/ChenjieXu/pyzxing)                                           | Python wrapper to ZXing library
 | [zxing-dart](https://github.com/shirne/zxing-dart)                                        | Port to dart
-| [rxing](https://github.com/hschimke/rxing)                                                | Port to rust
+| [rxing](https://github.com/rxing-core/rxing)                                                | Port to rust
 
 ### Other related third-party open source projects
 


### PR DESCRIPTION
Please update the link for the rust port of zxing (rxing), as the repository has moved